### PR TITLE
Add limitations section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,11 @@ try (Service python : env.python()) {
     // ...
 }
 ```
+
+## Limitations
+
+The current maximum size of an image that can be backed by an `ShmImg` is `2^31 - 1` bytes, 
+
+i.e. `ShmImg.copyOf( ArrayImgs.unsignedShorts( 1024, 1024, 1023 ) );` is possible,
+
+while `ShmImg.copyOf( ArrayImgs.unsignedShorts( 1024, 1024, 1024 ) );` leads to an Exception.


### PR DESCRIPTION
I am note unsure, if the size limitation of `ShmImg` is intended and or necessary, however I have hit it today and thought it would be useful to explicitly mention it in the docs, since it is not there yet.

This pull request adds documentation about this limitation. The update clarifies the maximum allowable size and provides examples of both acceptable and failing usage.

Documentation update:

* Added a "Limitations" section to `README.md` explaining that the maximum image size for `ShmImg` is `2^31 - 1` bytes, with code examples demonstrating the boundary condition.